### PR TITLE
add version number to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "georgringer/belayout-fileprovider",
   "type": "typo3-cms-extension",
   "description": "A File provider for Backend Layouts",
+  "version": "0.0.1",
   "homepage": "https://github.com/georgringer/belayout_fileprovider",
   "license": ["GPL-2.0+"],
   "keywords": ["TYPO3 CMS"],


### PR DESCRIPTION
fixes bug when activating extension with dependency on belayout_fileprovider: `Version number in composer manifest of package "belayout_fileprovider" is missing or invalid`
